### PR TITLE
Ensure tests actually check leaked values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: rust
+rust:
+  - stable
+  - beta
+  - nightly

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+* Leak a piece of data by never calling its destructor
+
+Useful for things that are going to be used for the life of the program, but aren't technically
+static (because they are created in response to arguments, environment, or other
+configuration/data read at program start).
+
+This is a modified version of the proposed rfc: https://github.com/rust-lang/rfcs/pull/1233
+
+Notable changes:
+- for user convenience, leak() is a non-static method
+- Return `&T` instead of `&mut T`
+
+While it would be ideal to return a `&'a mut T`, we apparently can't do that due to limitations
+in rust's borrow checker causing soundness issues. Details are in the RFC liked above.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,10 +82,21 @@ mod test {
     fn leak_box() {
         use super::Leak;
 
-        let v = Box::new(vec!["hi", "there"].into_boxed_slice());
+        let v : Box<[&str]> = vec!["hi", "there"].into_boxed_slice();
         {
             let o = v.clone();
-            let _ : &'static _ = o.leak();
+            let _ : &'static [&str] = o.leak();
         }
+    }
+
+    #[test]
+    fn leak_nested() {
+        use super::Leak;
+
+        let v : Box<Vec<&str>> = Box::new(vec!["hi", "there"]);
+        let _ = {
+            let o = v.clone();
+            let _ : &'static [&str] = o.leak();
+        };
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
 use std::mem;
 
 /**
- * Leak a piece of data by never calling it's desctructor
+ * Leak a piece of data by never calling its destructor
  *
  * Useful for things that are going to be used for the life of the program, but aren't technically
  * static (because they are created in response to arguments, environment, or other
- * configuration/data read at program start.
+ * configuration/data read at program start).
  *
  * This is a modified version of the proposed rfc: https://github.com/rust-lang/rfcs/pull/1233
  *

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,14 +57,17 @@ mod test {
         use std::borrow::ToOwned;
 
         let v = "hi";
-        {
+        let leaked : &str = {
             let o = v.to_owned();
-            let _ : &str = o.leak();
-        }
-        {
+            o.leak()
+        };
+        assert_eq!(leaked, v);
+
+        let leaked : &'static str = {
             let o = v.to_owned();
-            let _ : &'static str = o.leak();
-        }
+            o.leak()
+        };
+        assert_eq!(leaked, v);
     }
 
     #[test]
@@ -72,10 +75,11 @@ mod test {
         use super::Leak;
 
         let v = vec![3, 5];
-        {
+        let leaked : &'static [u8] = {
             let o = v.clone();
-            let _ : &'static [u8] = o.leak();
-        }
+            o.leak()
+        };
+        assert_eq!(leaked, &*v);
     }
 
     #[test]
@@ -83,10 +87,11 @@ mod test {
         use super::Leak;
 
         let v : Box<[&str]> = vec!["hi", "there"].into_boxed_slice();
-        {
+        let leaked : &'static [&str] = {
             let o = v.clone();
-            let _ : &'static [&str] = o.leak();
-        }
+            o.leak()
+        };
+        assert_eq!(leaked, &*v);
     }
 
     #[test]
@@ -94,9 +99,10 @@ mod test {
         use super::Leak;
 
         let v : Box<Vec<&str>> = Box::new(vec!["hi", "there"]);
-        let _ = {
+        let leaked : &'static [&str] = {
             let o = v.clone();
-            let _ : &'static [&str] = o.leak();
+            o.leak()
         };
+        assert_eq!(leaked, &**v);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -71,10 +71,35 @@ mod test {
     }
 
     #[test]
+    fn leak_empty_str() {
+        use super::Leak;
+        use std::borrow::ToOwned;
+
+        let v = "";
+        let leaked : &'static str = {
+            let o = v.to_owned();
+            o.leak()
+        };
+        assert_eq!(leaked, v);
+    }
+
+    #[test]
     fn leak_vec() {
         use super::Leak;
 
         let v = vec![3, 5];
+        let leaked : &'static [u8] = {
+            let o = v.clone();
+            o.leak()
+        };
+        assert_eq!(leaked, &*v);
+    }
+
+    #[test]
+    fn leak_empty_vec() {
+        use super::Leak;
+
+        let v = vec![];
         let leaked : &'static [u8] = {
             let o = v.clone();
             o.leak()


### PR DESCRIPTION
Added some additional files too, Travis & Readme, which I can drop if you want. (you'll probably have to enable Travis though)

I was thinking that the `Leak` trait made more sense to have an associated type `Leaked` rather than an input typeparam so it's easier to use in generic contexts and that each type can only have one impl, but I don't think the trait is going to be used much at all in generic contexts so I punted on the change.